### PR TITLE
Add support for JOINs with ON clause

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/sql-generator/index.js
+++ b/lib/sql-generator/index.js
@@ -216,6 +216,11 @@ var SqlGenerator = function( type ) {
             return key + ' ' + bop + ' $' + values.length;
         }
     };
+    self._gen_on = function(on_clause) {
+        var values = [];
+        var sql = self._gen_where(on_clause, values);
+        return "ON " + sql.replace(/\$(\d+)/g, function(x, y) { y = (y*1) - 1; return values[y]; });
+    };
     self._gen_select_column = function( columns ) {
         var column = '';
         var cols, key;
@@ -245,16 +250,28 @@ var SqlGenerator = function( type ) {
         return column;
     };
     self._gen_table = function( table ) {
-        var t = [];
+        var t = [], join_with = ', ', on_clause = '';
         if( table instanceof Array ) {
             for( var i = 0; i < table.length; i ++ ) {
-                if( typeof table[i] == 'object' )
-                    for( var k in table[i] )
-                        t.push( k + ' AS ' + table[i][k] );
-                else
+                if( typeof table[i] === 'object' ) {
+                    for( var k in table[i] ) {
+                        if(k.match(/_JOIN$/)) {
+                            t.push(k.replace("_"," "));
+                            on_clause = self._gen_on(table[i][k]);
+                            join_with = " ";
+                        } else {
+                            t.push( k + ' AS ' + table[i][k] );
+                        }
+                    }
+                } else {
                     t.push( table[i] );
+                    if(on_clause) {
+                        t.push(on_clause);
+                        on_clause = '';
+                    }
+                }
             }
-            return t.join(', ');
+            return t.join(join_with);
         }
         return table;
     };

--- a/lib/sql-generator/index.js
+++ b/lib/sql-generator/index.js
@@ -1,3 +1,4 @@
+/*jshint laxbreak: true, loopfunc: true, node: true*/
 //var sys = require('sys');
 var SqlGenerator = function( type ) {
     var self = this;
@@ -11,7 +12,7 @@ var SqlGenerator = function( type ) {
 //        console.log( sys.inspect( {table: table, columns: columns, where:wheres, opt:opt} ) );
         var table  = self._gen_table( tbls );
         var column = self._gen_select_column( columns );
-        var values = new Array;
+        var values = [];
         var where  = self._gen_where( wheres, values );
         var option = self._gen_select_option( opt );
 //        console.log( sys.inspect( { table: table, column: column, where: where, option: option } ) );
@@ -27,41 +28,41 @@ var SqlGenerator = function( type ) {
     self._gen_select_option = function( opt ) {
         if( !( typeof opt == 'object' && !(opt instanceof Array) ) )
             return '';
-        var sqls = new Array;
+        var sqls = [];
         // these code is postgresql only
-        if( opt['group_by'] ) {
-            if( typeof opt['group_by'] == 'object' && opt['group_by'] instanceof Array )
-                sqls.push( 'GROUP BY ' + opt['group_by'].join(', ') );
+        if( opt.group_by ) {
+            if( typeof opt.group_by === 'object' && opt.group_by instanceof Array )
+                sqls.push( 'GROUP BY ' + opt.group_by.join(', ') );
             else
-                sqls.push( 'GROUP BY ' + opt['group_by'] );
+                sqls.push( 'GROUP BY ' + opt.group_by );
         }
-        if( opt['order'] ) {
+        if( opt.order ) {
             var order = '';
-            if( opt['order'] instanceof Array )
-                order = opt['order'].join(', ');
+            if( opt.order instanceof Array )
+                order = opt.order.join(', ');
             else
-                order = opt['order'];
+                order = opt.order;
             sqls.push( 'ORDER BY ' + order );
         }
-        if( opt['limit'] && typeof opt['limit'] == 'number' )
-            sqls.push( 'LIMIT ' + opt['limit'] );
-        if( opt['offset'] && typeof opt['offset'] == 'number' )
-            sqls.push( 'OFFSET ' + opt['offset'] );
+        if( opt.limit && typeof opt.limit === 'number' )
+            sqls.push( 'LIMIT ' + opt.limit );
+        if( opt.offset && typeof opt.offset === 'number' )
+            sqls.push( 'OFFSET ' + opt.offset );
         return sqls.join(' ');
     };
     self._gen_where = function( tmp_where, values ) {
-        var w;
+        var w, ws;
         if( tmp_where ) {
             var where = JSON.parse( JSON.stringify( tmp_where ) );
             if( where instanceof Array ) {
-                var ws = new Array;
+                ws = [];
                 for( var i = 0; i < where.length; i ++ ) {
                     ws.push( self._recurse_where( values, where[i] ) );
                 }
                 w = ws.join(' OR ');
             }
             else if( typeof where == 'object' ) {
-                var ws = new Array;
+                ws = [];
                 for( var key in where )
                     ws.push( self._recurse_where( values, where[key], key ) );
                 w = ws.join(' AND ');
@@ -76,10 +77,11 @@ var SqlGenerator = function( type ) {
             bop = '=';
         if( !jk )
             jk = 'AND';
+        var vs = [], i, sql, tmp_values, new_sql;
         //var util = require('util');
         //console.log( util.inspect( { values: values, where: where, key: key, bop: bop, jk: jk }, false, 10 ) );
         if( key && key.toLowerCase() == '-or' ) {
-            var vs = new Array();
+            vs = [];
             if( where instanceof Array )
                 where.forEach( function( w ) {
                     vs.push( self._recurse_where( values, w, key, bop, 'OR' ) );
@@ -93,8 +95,7 @@ var SqlGenerator = function( type ) {
             return '(' + vs.join(' OR ') + ')';
         }
         else if( where instanceof Array ) {
-            var vs = new Array;
-            for( var i = 0; i < where.length; i ++ )
+            for( i = 0; i < where.length; i ++ )
                 vs.push( self._recurse_where( values, where[i], key, bop, jk ) );
             return '( ' + vs.join(' OR ') + ' )';
         }
@@ -105,11 +106,11 @@ var SqlGenerator = function( type ) {
                 return key + ' ' + bop + ' NULL';
         }
         else if( typeof where == 'object' ) {
-            var ws = new Array;
+            var ws = [];
             for( var op in where ) {
                 //console.log( '+++', { ws: ws, op: op, key:key, 'where[op]': where[op] } );
                 if( op.toLowerCase() == '-and' ) {
-                    var vs = new Array();
+                    vs = [];
                     where[op].forEach( function( w ) {
                         vs.push( self._recurse_where( values, w, key, bop, jk ) );
                     } );
@@ -120,24 +121,23 @@ var SqlGenerator = function( type ) {
                 }
                 else if( op.toLowerCase() == 'in' ) {
                     if( typeof where[op] == 'object'
-                        && typeof where[op]['sql'] == 'object'
-                        && where[op]['sql']['sql'] && where[op]['sql']['values'] ) {
-                        var sql = where[op]['sql']['sql'];
-                        var tmp_values = new Array();
-                        for( var i = where[op]['sql']['values'].length - 1; i >= 0; i -- ) {
-                            tmp_values.unshift( where[op]['sql']['values'][i] );
-                            var new_sql = sql.replace( '\$' + ( i + 1 ), '$' + ( values.length + i + 1 ) );
+                        && typeof where[op].sql === 'object'
+                        && where[op].sql.sql && where[op].sql.values ) {
+                        sql = where[op].sql.sql;
+                        tmp_values = [];
+                        for( i = where[op].sql.values.length - 1; i >= 0; i -- ) {
+                            tmp_values.unshift( where[op].sql.values[i] );
+                            new_sql = sql.replace( '\$' + ( i + 1 ), '$' + ( values.length + i + 1 ) );
                             sql = new_sql;
                         }
-                        for( var i = 0; i < tmp_values.length; i ++ )
+                        for( i = 0; i < tmp_values.length; i ++ )
                             values.push( tmp_values[i] );
                         ws.push( key + ' IN ( ' + sql + ' )' );
                     }
                     else if( typeof where[op] == 'string' && where[op].match('^(SELECT|select)') )
                         ws.push( key + ' IN ( ' + where[op] + ' ) ' );
                     else {
-                        var vs = new Array();
-                        for( var i = 0; i < where[op].length; i ++ ) {
+                        for( i = 0; i < where[op].length; i ++ ) {
                             values.push( where[op][i] );
                             vs.push( '$' + values.length );
                         }
@@ -171,23 +171,23 @@ var SqlGenerator = function( type ) {
                             sec = where[op];
                         }
                     } )();
-                    if( typeof sec['sql'] == 'object'
-                        && sec['sql']['sql'] && sec['sql']['values'] ) {
-                        var sql = sec['sql']['sql'];
-                        var tmp_values = new Array();
-                        for( var i = sec['sql']['values'].length - 1; i >= 0; i -- ) {
-                            tmp_values.unshift( sec['sql']['values'][i] );
-                            var new_sql = sql.replace( '\$' + ( i + 1 ), '$' + ( values.length + i + 1 ) );
+                    if( typeof sec.sql === 'object'
+                        && sec.sql.sql && sec.sql.values ) {
+                        sql = sec.sql.sql;
+                        tmp_values = [];
+                        for( i = sec.sql.values.length - 1; i >= 0; i -- ) {
+                            tmp_values.unshift( sec.sql.values[i] );
+                            new_sql = sql.replace( '\$' + ( i + 1 ), '$' + ( values.length + i + 1 ) );
                             sql = new_sql;
                         }
-                        for( var i = 0; i < tmp_values.length; i ++ )
+                        for( i = 0; i < tmp_values.length; i ++ )
                             values.push( tmp_values[i] );
                         ws.push( '(' + sql + ') ' + ary_op + ' ' + ary_fn + '(' + key + ')' );
                     }
                     else if( typeof sec == 'string' && sec.match('^(SELECT|select)') )
                         ws.push( '(' + sec + ') ' + ary_op + ' ' + ary_fn + '(' + key + ')' );
                     else if( sec instanceof Array ) {
-                        var vs = new Array();
+                        vs = [];
                         sec.forEach( function( v ) {
                             values.push( v );
                             vs.push( '$' + values.length + ' ' + ary_op + ' ' + ary_fn + '(' + key + ')' );
@@ -218,11 +218,12 @@ var SqlGenerator = function( type ) {
     };
     self._gen_select_column = function( columns ) {
         var column = '';
+        var cols, key;
         if( columns instanceof Array ) {
-            var cols = new Array;
+            cols = [];
             for( var i = 0; i < columns.length; i ++ ) {
                 if( typeof columns[i] == 'object' ) {
-                    for( var key in columns[i] )
+                    for( key in columns[i] )
                         cols.push( key + ' AS ' + columns[i][key] );
                 }
                 else
@@ -231,8 +232,8 @@ var SqlGenerator = function( type ) {
             column = cols.join(', ');
         }
         else if( typeof columns == 'object' ) {
-            var cols = new Array;
-            for( var key in columns )
+            cols = [];
+            for( key in columns )
                 cols.push( key + ' AS ' + columns[key] );
             column = cols.join(', ');
         }
@@ -244,7 +245,7 @@ var SqlGenerator = function( type ) {
         return column;
     };
     self._gen_table = function( table ) {
-        var t = new Array;
+        var t = [];
         if( table instanceof Array ) {
             for( var i = 0; i < table.length; i ++ ) {
                 if( typeof table[i] == 'object' )
@@ -259,9 +260,9 @@ var SqlGenerator = function( type ) {
     };
     self.insert = function( table, data, callback ) {
 //        console.log( sys.inspect( {table: table, data: data } ) );
-        var keys = new Array;
-        var values = new Array;
-        var pvalues = new Array;
+        var keys = [];
+        var values = [];
+        var pvalues = [];
         for( var key in data ) {
             keys.push( key );
             if( typeof data[key] == 'object' && data[key] instanceof Array ) {
@@ -277,7 +278,7 @@ var SqlGenerator = function( type ) {
                     pvalues.push( '$' + values.length );
                 }
                 else {
-                    var ary_vs = new Array();
+                    var ary_vs = [];
                     data[key].forEach( function( v ) {
                         values.push( v );
                         ary_vs.push( '$' + values.length );
@@ -297,8 +298,8 @@ var SqlGenerator = function( type ) {
     };
     self.update = function( table, wheres, data, callback ) {
         //console.log( sys.inspect( { table: table, where: wheres, data: data } ) );
-        var kvs = new Array;
-        var values = new Array;
+        var kvs = [];
+        var values = [];
         for( var key in data ) {
             if( typeof data[key] == 'object' && data[key] instanceof Array ) {
                 var is_num = true;
@@ -313,7 +314,7 @@ var SqlGenerator = function( type ) {
                     kvs.push( key + ' = $' + values.length );
                 }
                 else {
-                    var ary_vs = new Array();
+                    var ary_vs = [];
                     data[key].forEach( function( v ) {
                         values.push( v );
                         ary_vs.push( '$' + values.length );
@@ -336,7 +337,7 @@ var SqlGenerator = function( type ) {
     };
     self.delete = function( table, wheres, callback ) {
         //console.log( sys.inspect( { table: table, where: wheres } ) );
-        var values = new Array;
+        var values = [];
         var where = self._gen_where( wheres, values );
         var sql = 'DELETE FROM ' + table;
         if( where && where.length > 0 )
@@ -345,5 +346,5 @@ var SqlGenerator = function( type ) {
             return callback( sql, values );
         return { sql: sql, values: values };
     };
-}
+};
 module.exports = SqlGenerator;

--- a/test/0-main.js
+++ b/test/0-main.js
@@ -2,7 +2,7 @@ var SqlG;
 
 exports['test_load_module'] = function( test, assert ) {
     if( !assert ) { assert = test; assert.finish = function() { this.done() } }
-    SqlG = require('sql-generator');
+    SqlG = require('../lib/sql-generator');
     assert.ok( typeof SqlG === 'function');
     if( typeof test.finish == 'function' ) test.finish();
 };

--- a/test/1-select.js
+++ b/test/1-select.js
@@ -1,6 +1,6 @@
 var util = require('util');
 
-var SqlG = require('sql-generator');
+var SqlG = require('../lib/sql-generator');
 var sqlg = new SqlG();
 
 

--- a/test/1-select.js
+++ b/test/1-select.js
@@ -137,3 +137,13 @@ exports['test_parse_options'] = function( test, assert ) {
     
     if( typeof test.finish == 'function' ) test.finish();
 };
+
+exports.test_join = function( test, assert ) {
+    if( !assert ) { assert = test; assert.finish = function() { this.done() } }
+    
+    assert.deepEqual( { sql: 'SELECT * FROM T1 INNER JOIN T2 ON T1.this = T2.that INNER JOIN T3 ON T2.some = T3.other AND T2.i != T3.d', values: [] },
+                     sqlg.select(["T1",{ "INNER_JOIN": { "T1.this" : "T2.that" } }, "T2", { "INNER_JOIN": { "T2.some": "T3.other", "T2.i": {"!=": "T3.d"}}}, "T3"],
+                                 '*'));
+    
+    if( typeof test.finish == 'function' ) test.finish();
+}

--- a/test/2-insert.js
+++ b/test/2-insert.js
@@ -1,4 +1,4 @@
-var SqlG = require('sql-generator');
+var SqlG = require('../lib/sql-generator');
 var sqlg = new SqlG();
 
 exports['test_insert'] = function( test, assert ) {

--- a/test/3-update.js
+++ b/test/3-update.js
@@ -1,4 +1,4 @@
-var SqlG = require('sql-generator');
+var SqlG = require('../lib/sql-generator');
 var sqlg = new SqlG();
 
 exports['test_update'] = function( test, assert ) {

--- a/test/4-delete.js
+++ b/test/4-delete.js
@@ -1,4 +1,4 @@
-var SqlG = require('sql-generator');
+var SqlG = require('../lib/sql-generator');
 var sqlg = new SqlG();
 
 exports['test_delete'] = function( test, assert ) {


### PR DESCRIPTION
These changes add support for different JOINs in SELECT in a manner similar to Perl SQL::Abstract. Added to the select test to test the new feature. Also improved syntax to reflect JavaScript block scoping of variables, and generally accepted best practices in creating arrays and accessing object properties.

Below is an example of using the new join feature and the sql generated.

``` javascript
var SqlG = require('sql-generator');
var sqlg = new SqlG();

var tables = [
    "T1",
    {
        "INNER_JOIN": { "T1.this": "T2.that" } 
    }, 
    "T2", 
    { 
        "INNER_JOIN": { "T2.some": "T3.other", "T2.i": { "!=": "T3.d" } } 
    }, 
    "T3"
];
var stmt = sqlg.select(tables, "*");
// stmt.sql => 'SELECT * FROM T1 INNER JOIN T2 ON T1.this = T2.that INNER JOIN T3 ON T2.some = T3.other AND T2.i != T3.d'
```
